### PR TITLE
Static assets not reachable due to ingress prefix

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,8 @@ spring:
   thymeleaf:
     reactive:
       max-chunk-size: 8192
+  webflux:
+    static-path-pattern: /_oauth/assets/**
 logging:
   level:
     root: error

--- a/src/main/resources/templates/logged-out.html
+++ b/src/main/resources/templates/logged-out.html
@@ -10,7 +10,7 @@
     <body class="bg-gray-100 flex items-center justify-center min-h-screen">
         <div class="bg-white shadow-md rounded-lg w-full max-w-xl p-8">
             <div class="flex items-center mb-6">
-                <img th:src="@{/images/novari-logo.png}" alt="Novari Logo" class="w-32">
+                <img th:src="@{/_oauth/assets/images/novari-logo.png}" alt="Novari Logo" class="w-32">
             </div>
             <div class="text-center">
                 <p class="text-xl font-semibold text-gray-900 mb-4" th:text="${message}"></p>


### PR DESCRIPTION
Only traffic prefixed with `**/_oauth` is passed to the sso server. Assets was not served with `_oauth` prefix resulting in 404 when trying to fetch. 